### PR TITLE
完善预组队判断相关

### DIFF
--- a/app/components/summoner_name_button.py
+++ b/app/components/summoner_name_button.py
@@ -1,3 +1,4 @@
+from PyQt5.QtGui import QFontMetrics
 from PyQt5.QtWidgets import QPushButton
 from PyQt5.QtCore import Qt
 
@@ -8,3 +9,7 @@ class SummonerName(QPushButton):
         super().__init__(parent)
         self.setCursor(Qt.PointingHandCursor)
         self.setText(text)
+
+    # TODO 16字符或8中文名字会超出控件
+    def resizeEvent(self, event):
+        super().resizeEvent(event)

--- a/app/lol/tools.py
+++ b/app/lol/tools.py
@@ -356,12 +356,16 @@ def processGameDetailData(puuid, game):
 
 
 def getTeammates(game, targetPuuid):
+    targetParticipantId = None
+
     for participant in game['participantIdentities']:
         puuid = participant['player']['puuid']
 
         if puuid == targetPuuid:
             targetParticipantId = participant['participantId']
             break
+
+    assert targetParticipantId is not None
 
     for player in game['participants']:
         if player['participantId'] == targetParticipantId:


### PR DESCRIPTION
1. 修复游戏开始后, 获取敌方预组队信息出错  5d608ac6088d3be2d4966c11e80dec87aba16e44
2. 更明显的预组队标识 