### PR TITLE
[Github Actions] Fix Github Actions

### DIFF
--- a/.github/workflows/build_seraphine.yaml
+++ b/.github/workflows/build_seraphine.yaml
@@ -1,6 +1,10 @@
 name: Build Seraphine
 
 on:
+  push:
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -33,21 +37,28 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Setup environment variables
       run: |
-        export VERSION=`python -c "from app.common.config import VERSION; print(VERSION)"`
+        export VERSION_CHANGED_COMMIT_HASH=$(git blame app/common/config.py --root -l | grep -Po "([\w]+) (?=\(.*\) VERSION = )")
+        export HEAD_COMMIT_HASH=$(git log -1 --format='%H')
+        export UPDATED=$(python -c "import os; UPDATED = 'true' if os.environ['HEAD_COMMIT_HASH'].strip() == os.environ['VERSION_CHANGED_COMMIT_HASH'].strip() else 'false'; print(UPDATED)")
+        export VERSION=$(cat app/common/config.py | grep -Po "(?<=VERSION = \")(.*[^\"])")
         echo "VERSION=v$VERSION" >> $GITHUB_ENV
+        echo "UPDATED=$UPDATED" >> $GITHUB_ENV
     - name: Download artifact
       uses: actions/download-artifact@v3
+      if: env.UPDATED == 'true'
       with:
         name: Seraphine
         path: ./
     - name: Push to release
       uses: ncipollo/release-action@v1
+      if: env.UPDATED == 'true'
       with:
         name: Seraphine ${{ env.VERSION }}
         tag: ${{ env.VERSION }}
-        omitBodyDuringUpdate: true
         token: ${{ secrets.GITHUB_TOKEN }}
-        allowUpdates: false
+        replacesArtifacts: false
         artifacts: Seraphine.zip


### PR DESCRIPTION
## TL; DR

修复了 Github Actions 的非预期行为。

## Changes
1. 当且仅当修改 `app/common/config.py` 下的 VERSION 变量时，才下载产物，并推送到 Release。
- 通过正则匹配 git blame 获取 VERSION = "x.x.x" 行的修改 commit 的 sha 值。
- 通过正则匹配 git log 获取 HEAD commit 的 sha 值。
- 比较两者，当两者相同时，证明该 commit 修改了版本号，需要触发后续操作；否则跳过后续操作。
- 触发下载产物和推送到 Release

2. 添加 `replacesArtifacts: false`，不允许新生成的产物覆盖旧产物。

这次应该是 ok 了~