### PR TITLE
fix make script redundant -r

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -12,7 +12,7 @@ cpi .\app -destination .\dist\Seraphine -recurse
 rm -r .\dist\Seraphine\app\common
 rm -r .\dist\Seraphine\app\components
 rm -r .\dist\Seraphine\app\lol
-rm -r .\dist\Seraphine\app\config\config.json
+rm .\dist\Seraphine\app\config\config.json
 rm -r .\dist\Seraphine\app\resource\game
 rm -r .\dist\Seraphine\app\resource\i18n\Seraphine.zh_CN.ts
 rm -r .\dist\Seraphine\app\view


### PR DESCRIPTION
删除打包脚本中多余的 `-r`