### PR TITLE
临时修复最小化到托盘时, 右键菜单位置不正确的BUG

### DIFF
--- a/app/components/summoner_name_button.py
+++ b/app/components/summoner_name_button.py
@@ -9,7 +9,3 @@ class SummonerName(QPushButton):
         super().__init__(parent)
         self.setCursor(Qt.PointingHandCursor)
         self.setText(text)
-
-    # TODO 16字符或8中文名字会超出控件
-    def resizeEvent(self, event):
-        super().resizeEvent(event)

--- a/app/view/main_window.py
+++ b/app/view/main_window.py
@@ -5,7 +5,7 @@ import time
 from collections import Counter
 
 from PyQt5.QtCore import Qt, pyqtSignal, QSize
-from PyQt5.QtGui import QIcon, QImage
+from PyQt5.QtGui import QIcon, QImage, QCursor
 from PyQt5.QtWidgets import QApplication, QSystemTrayIcon
 from qfluentwidgets import (NavigationItemPosition, InfoBar, InfoBarPosition,
                             FluentWindow, SplashScreen, MessageBox, SmoothScrollArea, SystemTrayMenu, Action)
@@ -199,7 +199,18 @@ class MainWindow(FluentWindow):
             lambda: showAndSwitch(self.settingInterface))
         quitAction.triggered.connect(quit)
 
-        self.trayMenu = SystemTrayMenu(self)
+        class TmpSystemTrayMenu(SystemTrayMenu):
+            def adjustPosition(self):
+                m = self.layout().contentsMargins()
+                rect = QApplication.screenAt(QCursor.pos()).availableGeometry()
+                w, h = self.layout().sizeHint().width() + 5, self.layout().sizeHint().height()
+
+                x = min(self.x() - m.left(), rect.right() - w)
+                y = QCursor.pos().y() - self.height() + m.bottom()
+
+                self.move(x, y)
+
+        self.trayMenu = TmpSystemTrayMenu(self)
 
         self.trayMenu.addAction(careerAction)
         self.trayMenu.addAction(searchAction)

--- a/app/view/setting_interface.py
+++ b/app/view/setting_interface.py
@@ -244,6 +244,7 @@ class SettingInterface(SmoothScrollArea):
         self.lolFolderCard.setContent(folder)
 
     def __showRestartToolTip(self):
+        # TODO 改为应用成功提示, 添加历史战绩刷新按钮
         InfoBar.success(self.tr("Updated successfully"),
                         self.tr("Configuration takes effect after restart"),
                         duration=2000,


### PR DESCRIPTION
#44 

作为 pyqt-fluent-widgets 修复前的临时措施