### PR TITLE
对局信息相关修复和改动

### DIFF
--- a/app/view/game_info_interface.py
+++ b/app/view/game_info_interface.py
@@ -82,6 +82,9 @@ class GameInfoInterface(SmoothScrollArea):
         self.summonersView.enemySummoners.updateSummoners(info['summoners'])
         self.enemySummonerGamesView.updateSummoners(info['summoners'])
 
+        self.summonersView.allyButton.setVisible(True)
+        self.summonersView.enemyButton.setVisible(True)
+
     def __onGameEnd(self):
         self.summonersView.allySummoners.clear()
         self.summonersView.enemySummoners.clear()
@@ -226,6 +229,7 @@ class SummonerInfoView(QFrame):
     def __init__(self, info: dict, parent=None):
         super().__init__(parent)
         self.hBoxLayout = QHBoxLayout(self)
+        self.nowIconId = ''
         self.icon = RoundLevelAvatar(info['icon'],
                                      info['xpSinceLastLevel'],
                                      info['xpUntilNextLevel'],
@@ -416,6 +420,7 @@ class SummonerInfoView(QFrame):
         QApplication.restoreOverrideCursor()
 
     def updateIcon(self, iconPath: str):
+        self.nowIconId = iconPath.split("/")[-1][:-4]
         self.icon.updateIcon(iconPath)
 
 


### PR DESCRIPTION
1. 修复对局开始后再打开软件"对局信息"页会显示为空 #53 
2. 降低"对局信息"页, 召唤师图标更新频率(仅差异时触发图标更新) 
https://github.com/Zzaphkiel/Seraphine/blob/e86545a2ff2849510bff65e9a6e8622a528e54d7/app/view/main_window.py#L706C1-L706C1
3. 添加"游戏中"状态自动跳转到"对局信息"页
4. "对局信息"页的自动跳转改为渲染完成后触发