### PR TITLE
修复执行战绩查询操作后, 其他功能受到影响的BUG

### DIFF
--- a/app/view/search_interface.py
+++ b/app/view/search_interface.py
@@ -1077,7 +1077,7 @@ class SearchInterface(SmoothScrollArea):
         self.queueIdBuffer = {}
         gameIdx = 0
         begIdx = 0
-        endIdx = begIdx + 99
+        endIdx = begIdx + 19
         while True:
             games = connector.getSummonerGamesByPuuid(
                 puuid, begIdx, endIdx)
@@ -1103,7 +1103,7 @@ class SearchInterface(SmoothScrollArea):
                 gameIdx += 1
 
             begIdx = endIdx + 1
-            endIdx += 99
+            endIdx += 19
 
     def __onSummonerPuuidGetted(self, puuid):
         if puuid != "-1":

--- a/app/view/search_interface.py
+++ b/app/view/search_interface.py
@@ -1077,9 +1077,9 @@ class SearchInterface(SmoothScrollArea):
         self.queueIdBuffer = {}
         gameIdx = 0
         begIdx = 0
-        endIdx = begIdx + 19
+        endIdx = begIdx + 9
         while True:
-            games = connector.getSummonerGamesByPuuid(
+            games = connector.getSummonerGamesByPuuidSlowly(
                 puuid, begIdx, endIdx)
 
             if not games["games"]:  # 所有对局都在一年内, 查完了
@@ -1103,7 +1103,7 @@ class SearchInterface(SmoothScrollArea):
                 gameIdx += 1
 
             begIdx = endIdx + 1
-            endIdx += 19
+            endIdx += 9
 
     def __onSummonerPuuidGetted(self, puuid):
         if puuid != "-1":


### PR DESCRIPTION
目前推测是由于异步加载战绩导致其余战绩获取的请求无法被及时响应, 影响了以下功能:
1. 对局信息(获取历史战绩时)
2. 个人主页(获取历史战绩时)

该pr降低了战绩查询时异步获取数据的步长, 并将接口改为可被抢断的以保证其他功能的请求能够被及时响应