### PR TITLE
修复以及优化

### DIFF
--- a/app/view/main_window.py
+++ b/app/view/main_window.py
@@ -801,7 +801,11 @@ class MainWindow(FluentWindow):
             isGaming = True
         elif status == 'InProgress':
             title = self.tr("Gaming")
-            self.__onGameStart()
+            if not self.isGaming:
+                print("update gameinfo")
+                self.__onGameStart()
+            else:
+                print("重连")
             isGaming = True
         elif status == 'WaitingForStatus':
             title = self.tr("Waiting for status")
@@ -810,6 +814,7 @@ class MainWindow(FluentWindow):
         elif status == 'Lobby':
             title = self.tr("Lobby")
             self.__onGameEnd()
+            self.switchTo(self.careerInterface)
         elif status == 'ReadyCheck':
             title = self.tr("Ready check")
             self.__onMatchMade()

--- a/app/view/main_window.py
+++ b/app/view/main_window.py
@@ -801,6 +801,7 @@ class MainWindow(FluentWindow):
             isGaming = True
         elif status == 'InProgress':
             title = self.tr("Gaming")
+            # 重连或正常进入游戏(走GameStart), 不需要更新数据
             if not self.isGaming:
                 self.__onGameStart()
             isGaming = True

--- a/app/view/main_window.py
+++ b/app/view/main_window.py
@@ -802,10 +802,7 @@ class MainWindow(FluentWindow):
         elif status == 'InProgress':
             title = self.tr("Gaming")
             if not self.isGaming:
-                print("update gameinfo")
                 self.__onGameStart()
-            else:
-                print("重连")
             isGaming = True
         elif status == 'WaitingForStatus':
             title = self.tr("Waiting for status")

--- a/app/view/search_interface.py
+++ b/app/view/search_interface.py
@@ -278,13 +278,14 @@ class GamesTab(QFrame):
         self.stackWidget.setCurrentIndex(self.currentIndex)
         self.pageLabel.setText(f"{self.currentIndex}")
 
-        if self.first:
+        if self.triggerGameId:
+            self.tabClicked.emit(str(self.triggerGameId))
+            self.triggerGameId = 0
+        elif self.first:
             gameId = layout.itemAt(0).widget().gameId
             self.tabClicked.emit(str(gameId))
             self.first = False
-        elif self.triggerGameId:
-            self.tabClicked.emit(str(self.triggerGameId))
-            self.triggerGameId = 0
+
 
         mainWindow = self.window()
         mainWindow.checkAndSwitchTo(mainWindow.searchInterface)


### PR DESCRIPTION
1. 稳定性: 增加LCU API 引用计数, 同一时间并发数量不会超过3个. (此前并发数量过多有概率导致LCU客户端闪退)
2. 易用性: 在游戏结束后, 自动切换至生涯页
3. 性能优化: 在进行重连时, 不再消耗资源重新获取"对局信息"页数据
4. BUG修复: 当从生涯页面点击某一局历史游戏跳转到战绩查询页时, 仍显示最近一局的详情(正确应为点击的那一局)