### PR TITLE
bugfix #158 #170

### DIFF
--- a/app/common/config.py
+++ b/app/common/config.py
@@ -51,7 +51,7 @@ class Config(QConfig):
                                  restart=True)
 
     careerGamesNumber = RangeConfigItem("Functions", "CareerGamesNumber", 20,
-                                        RangeValidator(1, 999))
+                                        RangeValidator(1, 60))
 
     teamGamesNumber = RangeConfigItem("Functions", "TeamGamesNumber", 1,
                                       RangeValidator(1, 10))

--- a/app/lol/connector.py
+++ b/app/lol/connector.py
@@ -44,7 +44,7 @@ def retry(count=5, retry_sep=0):
         def wrapper(*args, **kwargs):
             exce = None
             for _ in range(count):
-                while connector.ref_cnt >= 3:
+                while connector.ref_cnt >= 2:
                     time.sleep(.2)
 
                 connector.ref_cnt += 1

--- a/app/lol/listener.py
+++ b/app/lol/listener.py
@@ -12,7 +12,10 @@ def getLolProcessPid():
 
     if b'LeagueClientUx.exe' in processes:
         arr = processes.split()
-        return int(arr[1])
+        try:
+            return int(arr[1])
+        except ValueError:
+            raise ValueError(f"Subprocess return exception: {processes}")
     else:
         return 0
 


### PR DESCRIPTION
BUG修复: 请求量过大时导致的LCU客户端闪退, 最大并发数改为2 #158
BUG修复: "显示对局数"过高导致的LCU API拒绝请求, 该选项的上限值设置为60 #170
易用性: 为检测LCU启动的未知错误添加了异常抛出, 再次遇到时可以具体定位问题 #174