### PR TITLE
[bugfix] Fix profile_level_icon_widget paintEvent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ render.html
 
 # 忽略日志文件
 log
+
+# 忽略虚拟环境
+venv
+seraphine

--- a/app/components/profile_level_icon_widget.py
+++ b/app/components/profile_level_icon_widget.py
@@ -88,8 +88,8 @@ class RoundLevelAvatar(QWidget):
         painter.setRenderHint(QPainter.Antialiasing)
 
         scaledImage = self.image.scaled(
-            self.width() - self.sep,
-            self.height() - self.sep,
+            self.width() - int(self.sep),
+            self.height() - int(self.sep),
             Qt.AspectRatioMode.KeepAspectRatioByExpanding)
 
         clipPath = QPainterPath()
@@ -98,7 +98,7 @@ class RoundLevelAvatar(QWidget):
                             self.height() - self.sep)
 
         painter.setClipPath(clipPath)
-        painter.drawImage(self.sep // 2, self.sep // 2, scaledImage)
+        painter.drawImage(int(self.sep // 2), int(self.sep // 2), scaledImage)
 
     def updateIcon(self, icon: str, xpSinceLastLevel=None, xpUntilNextLevel=None, text=""):
         self.image = QImage(icon)


### PR DESCRIPTION
修复 #74 的报错问题。

当使用 python 3.11 通过源码运行 seraphine 时，会报错 `QPaintDevice: Cannot destroy paint device that is being painted`。

因为 `app/components/profile_level_icon_widget.py` 中的 `RoundLevelAvatar.paintEvent()` 函数内有两处函数调用的参数类型有误，参数的期望类型是 int，但是输入的 `self.sep` 和 `self.sep // 2` 是 float 类型的，所以引发错误。解决方法就是显式转换成 int 类型。

修复后，通过源码运行，软件行为正常。

此外，在 .gitignore 文件中，忽略 `venv/` 和 `seraphine/`。