### PR TITLE
BUG FIX : 战绩查询相关BUG

### DIFF
--- a/app/view/main_window.py
+++ b/app/view/main_window.py
@@ -873,6 +873,7 @@ class MainWindow(FluentWindow):
         self.checkAndSwitchTo(self.searchInterface)
 
         await self.searchInterface.searchAndShowFirstPage()
+        self.searchInterface.loadingGameId = gameId
         await self.searchInterface.updateGameDetailView(gameId)
         self.searchInterface.waitingForDrawSelect(gameId)
 

--- a/app/view/search_interface.py
+++ b/app/view/search_interface.py
@@ -149,7 +149,7 @@ class GamesTab(QFrame):
         self.prevButton.setEnabled(prevEnable)
 
         nextEnable = len(
-            self.queueIdMap[self.queueId]) > self.currentPageNum * 10
+            self.queueIdMap.get(self.queueId, [])) > self.currentPageNum * 10
         self.nextButton.setEnabled(nextEnable)
 
     def prepareNextPage(self):

--- a/app/view/search_interface.py
+++ b/app/view/search_interface.py
@@ -928,6 +928,8 @@ class SearchInterface(SmoothScrollArea):
         self.gamesView = GamesView()
         self.currentSummonerName = None
 
+        self.detailViewLoadTask = None
+
         self.__initWidget()
         self.__initLayout()
         self.__connectSignalToSlot()
@@ -1120,6 +1122,10 @@ class SearchInterface(SmoothScrollArea):
         tabs: GamesTab = self.gamesView.gamesTab
         cur: GameTab = tabs.currentTabSelected
 
+        self.gamesView.gameDetailView.clear()
+        if self.gameLoadingTask:
+            self.gameLoadingTask.cancel()
+
         if tab is cur:
             return
 
@@ -1131,7 +1137,7 @@ class SearchInterface(SmoothScrollArea):
             cur.style().polish(cur)
 
         tabs.currentTabSelected = tab
-        await self.updateGameDetailView(tab.gameId)
+        self.detailViewLoadTask = asyncio.create_task(self.updateGameDetailView(tab.gameId))
 
     async def updateGameDetailView(self, gameId):
         if cfg.get(cfg.showTierInGameInfo):


### PR DESCRIPTION
1. 修复战绩筛选时, 若一个人从未打过被筛选的模式, 会keyError的bug
2. 修复加载战绩详情时, 如果频繁切换查询的场次, 会导致await self.updateGameDetailView(tab.gameId)积压, 加载时间很长, 并且直到最终全部加载完成后才会一次连续更新很多场(每场一闪而过)