### PR TITLE
BUG FIX: 弱网下Rank信息获取出错; 战绩查询逻辑导致效率问题; 生涯页加载速度; 添加崩溃时InterfaceLog

### DIFF
--- a/app/components/SeraphineInterface.py
+++ b/app/components/SeraphineInterface.py
@@ -1,0 +1,11 @@
+from PyQt5.sip import wrapper
+
+from app.common.qfluentwidgets import SmoothScrollArea
+
+
+class SeraphineInterface(SmoothScrollArea):
+    def __str__(self):
+        methods = [attr for attr in dir(self) if callable(getattr(self, attr))]
+        attrs = [f"{k}({type(v).__name__})={v!r}" for k, v in self.__dict__.items() if
+                 not isinstance(v, wrapper) and k not in methods]
+        return f"{self.__class__.__name__}(\n  {', '.join(attrs)}\n)"

--- a/app/lol/connector.py
+++ b/app/lol/connector.py
@@ -32,6 +32,7 @@ class PastRequest:
         self.timestamp = time.time()
 
     def __str__(self):
+        # 如果是None的成员, 不会被打印; 没打印response就是没有响应;
         attrs = [f"{k}={v!r}" for k, v in self.__dict__.items() if v is not None]
         return f"PastRequest(\n  {', '.join(attrs)}\n)"
 
@@ -503,7 +504,12 @@ class LolClientConnector(QObject):
     async def getRankedStatsByPuuid(self, puuid):
         res = await self.__get(f"/lol-ranked/v1/ranked-stats/{puuid}")
 
-        return await res.json()
+        res = await res.json()
+
+        if "errorCode" in res:
+            raise SummonerRankInfoNotFound()
+
+        return res
 
     @retry()
     async def setProfileBackground(self, skinId):

--- a/app/lol/connector.py
+++ b/app/lol/connector.py
@@ -196,6 +196,7 @@ class LolClientConnector(QObject):
 
     def __init__(self):
         super().__init__()
+        self.semaphore = None
         self.sess = None
         self.port = None
         self.token = None

--- a/app/lol/exceptions.py
+++ b/app/lol/exceptions.py
@@ -6,6 +6,10 @@ class SummonerGamesNotFound(BaseException):
     pass
 
 
+class SummonerRankInfoNotFound(BaseException):
+    pass
+
+
 class SummonerNotInGame(BaseException):
     pass
 

--- a/app/lol/tools.py
+++ b/app/lol/tools.py
@@ -105,17 +105,15 @@ async def getRecentTeammates(games, puuid):
     return ret
 
 
-async def parseSummonerData(summoner):
+async def parseSummonerData(summoner, rankTask, gameTask):
     iconId = summoner['profileIconId']
     icon = await connector.getProfileIcon(iconId)
     level = summoner['summonerLevel']
     xpSinceLastLevel = summoner['xpSinceLastLevel']
     xpUntilNextLevel = summoner['xpUntilNextLevel']
-    rankInfo = await connector.getRankedStatsByPuuid(summoner['puuid'])
 
     try:
-        gamesInfo = await connector.getSummonerGamesByPuuid(
-            summoner['puuid'], 0, cfg.get(cfg.careerGamesNumber) - 1)
+        gamesInfo = await gameTask
     except:
         champions = []
         games = {}
@@ -152,7 +150,7 @@ async def parseSummonerData(summoner):
         'xpSinceLastLevel': xpSinceLastLevel,
         'xpUntilNextLevel': xpUntilNextLevel,
         'puuid': summoner['puuid'],
-        'rankInfo': rankInfo,
+        'rankInfo': await rankTask,
         'games': games,
         'champions': champions,
         'isPublic': summoner['privacy'] == "PUBLIC",

--- a/app/lol/tools.py
+++ b/app/lol/tools.py
@@ -10,6 +10,7 @@ import asyncio
 from PyQt5.QtCore import QObject
 from PyQt5.QtWidgets import QApplication
 
+from .exceptions import SummonerRankInfoNotFound
 from ..common.config import cfg, Language
 from ..lol.connector import LolClientConnector, connector
 
@@ -143,6 +144,11 @@ async def parseSummonerData(summoner, rankTask, gameTask):
 
         champions = getRecentChampions(games['games'])
 
+    try:
+        rankInfo = await rankTask
+    except SummonerRankInfoNotFound:
+        rankInfo = {}
+
     return {
         'name': summoner.get("gameName") or summoner['displayName'],
         'icon': icon,
@@ -150,7 +156,7 @@ async def parseSummonerData(summoner, rankTask, gameTask):
         'xpSinceLastLevel': xpSinceLastLevel,
         'xpUntilNextLevel': xpUntilNextLevel,
         'puuid': summoner['puuid'],
-        'rankInfo': await rankTask,
+        'rankInfo': rankInfo,
         'games': games,
         'champions': champions,
         'isPublic': summoner['privacy'] == "PUBLIC",
@@ -378,14 +384,16 @@ async def parseGameDetailData(puuid, game):
 
                 getRankInfo = cfg.get(cfg.showTierInGameInfo)
 
-                tier, division, lp, rankIcon = None, None, None, None
+                tier = division = lp = rankIcon = ""
                 if getRankInfo:
-                    rank = await connector.getRankedStatsByPuuid(
-                        summonerPuuid)
-                    rank = rank.get('queueMap')
-
                     try:
-                        if queueId != 1700 and rank:
+                        rank = await connector.getRankedStatsByPuuid(
+                            summonerPuuid)
+                    except SummonerRankInfoNotFound:
+                        ...
+                    else:
+                        rank = rank['queueMap']
+                        if queueId != 1700:
                             rankInfo = rank[
                                 'RANKED_FLEX_SR'] if queueId == 440 else rank['RANKED_SOLO_5x5']
 
@@ -404,8 +412,6 @@ async def parseGameDetailData(puuid, game):
                         else:
                             rankInfo = rank["CHERRY"]
                             lp = rankInfo['ratedRating']
-                    except KeyError:
-                        ...
 
                 item = {
                     'summonerName': summonerName,
@@ -546,32 +552,48 @@ def getRecentChampions(games):
 
 
 def parseRankInfo(info):
-    soloRankInfo = info["queueMap"]["RANKED_SOLO_5x5"]
-    flexRankInfo = info["queueMap"]["RANKED_FLEX_SR"]
+    """
+    解析 getRankedStatsByPuuid 的数据;
+    /lol-ranked/v1/ranked-stats/{puuid}
 
-    soloTier = soloRankInfo["tier"]
-    soloDivision = soloRankInfo["division"]
+    :param info: 接口返回值, 允许为空 (接口异常时抛出SummonerRankInfoNotFound, 需要捕获置空)
 
-    if soloTier == "":
-        soloIcon = "app/resource/images/UNRANKED.svg"
-        soloTier = "Unranked" if cfg.language.value == Language.ENGLISH else "未定级"
-    else:
-        soloIcon = f"app/resource/images/{soloTier}.svg"
-        soloTier = translateTier(soloTier, True)
-    if soloDivision == "NA":
-        soloDivision = ""
+    """
+    soloIcon = flexIcon = "app/resource/images/UNRANKED.svg"
+    # FIXME 中英以外的语言? -- By Hpero4
+    soloTier = flexTier = "Unknown" if cfg.language.value == Language.ENGLISH else "无数据"
+    soloDivision = flexDivision = ""
+    soloRankInfo = flexRankInfo = {"leaguePoints": ""}
 
-    flexTier = flexRankInfo["tier"]
-    flexDivision = flexRankInfo["division"]
+    if info:
+        soloRankInfo = info["queueMap"]["RANKED_SOLO_5x5"]
+        flexRankInfo = info["queueMap"]["RANKED_FLEX_SR"]
 
-    if flexTier == "":
-        flexIcon = "app/resource/images/UNRANKED.svg"
-        flexTier = "Unranked" if cfg.language.value == Language.ENGLISH else "未定级"
-    else:
-        flexIcon = f"app/resource/images/{flexTier}.svg"
-        flexTier = translateTier(flexTier, True)
-    if flexDivision == "NA":
-        flexDivision = ""
+        soloTier = soloRankInfo["tier"]
+        soloDivision = soloRankInfo["division"]
+
+        if soloTier == "":
+            soloIcon = "app/resource/images/UNRANKED.svg"
+            # FIXME 中英以外的语言? -- By Hpero4
+            soloTier = "Unranked" if cfg.language.value == Language.ENGLISH else "未定级"
+        else:
+            soloIcon = f"app/resource/images/{soloTier}.svg"
+            soloTier = translateTier(soloTier, True)
+        if soloDivision == "NA":
+            soloDivision = ""
+
+        flexTier = flexRankInfo["tier"]
+        flexDivision = flexRankInfo["division"]
+
+        if flexTier == "":
+            flexIcon = "app/resource/images/UNRANKED.svg"
+            # FIXME 中英以外的语言? -- By Hpero4
+            flexTier = "Unranked" if cfg.language.value == Language.ENGLISH else "未定级"
+        else:
+            flexIcon = f"app/resource/images/{flexTier}.svg"
+            flexTier = translateTier(flexTier, True)
+        if flexDivision == "NA":
+            flexDivision = ""
 
     return {
         "solo": {
@@ -869,7 +891,11 @@ async def parseSummonerGameInfo(item, isRank, currentSummonerId):
     icon = await connector.getChampionIcon(championId)
 
     puuid = summoner["puuid"]
-    origRankInfo = await connector.getRankedStatsByPuuid(puuid)
+    try:
+        origRankInfo = await connector.getRankedStatsByPuuid(puuid)
+    except SummonerRankInfoNotFound:
+        origRankInfo = None
+
     rankInfo = parseRankInfo(origRankInfo)
 
     try:

--- a/app/view/auxiliary_interface.py
+++ b/app/view/auxiliary_interface.py
@@ -11,6 +11,7 @@ from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QWidget, QLabel, QCompleter, QVBoxLayout, QHBoxLayout, QGridLayout, QLineEdit
 from qasync import asyncSlot
 
+from ..components.SeraphineInterface import SeraphineInterface
 from ..lol.tools import fixLeagueClientWindow
 from ..common.icons import Icon
 from ..common.config import cfg
@@ -19,7 +20,7 @@ from ..lol.connector import connector
 from ..lol.exceptions import *
 
 
-class AuxiliaryInterface(SmoothScrollArea):
+class AuxiliaryInterface(SeraphineInterface):
 
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/app/view/career_interface.py
+++ b/app/view/career_interface.py
@@ -88,6 +88,8 @@ class CareerInterface(SmoothScrollArea):
 
         self.games = []
 
+        self.loadGamesTask = None
+
         self.__initWidget()
         self.__initLayout()
         self.__connectSignalToSlot()
@@ -367,8 +369,10 @@ class CareerInterface(SmoothScrollArea):
 
         if summoner is None:
             summoner = await connector.getSummonerByPuuid(puuid)
+        self.loadGamesTask = asyncio.create_task(connector.getSummonerGamesByPuuid(summoner['puuid'], 0, cfg.get(cfg.careerGamesNumber) - 1))
+        rankTask = asyncio.create_task(connector.getRankedStatsByPuuid(summoner['puuid']))
 
-        info = await parseSummonerData(summoner)
+        info = await parseSummonerData(summoner, rankTask, self.loadGamesTask)
         await self.repaintInterface(info)
 
     async def repaintInterface(self, info):

--- a/app/view/career_interface.py
+++ b/app/view/career_interface.py
@@ -23,6 +23,7 @@ from app.common.config import cfg
 from app.lol.connector import connector
 from app.lol.tools import (parseGames, parseSummonerData,
                            getRecentTeammates, parseDetailRankInfo)
+from ..components.SeraphineInterface import SeraphineInterface
 
 
 class NameLabel(QLabel):
@@ -35,7 +36,7 @@ class TagLineLabel(QLabel):
         return super().text().replace(" ", '')
 
 
-class CareerInterface(SmoothScrollArea):
+class CareerInterface(SeraphineInterface):
     gameInfoBarClicked = pyqtSignal(str)
     iconLevelExpChanged = pyqtSignal(dict)
 

--- a/app/view/game_info_interface.py
+++ b/app/view/game_info_interface.py
@@ -20,9 +20,10 @@ from app.components.summoner_name_button import SummonerName
 from app.components.animation_frame import CardWidget, ColorAnimationFrame
 from app.lol.tools import parseSummonerOrder
 from app.lol.connector import connector
+from ..components.SeraphineInterface import SeraphineInterface
 
 
-class GameInfoInterface(SmoothScrollArea):
+class GameInfoInterface(SeraphineInterface):
 
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/app/view/main_window.py
+++ b/app/view/main_window.py
@@ -441,6 +441,7 @@ class MainWindow(FluentWindow):
 
     @asyncSlot(int)
     async def __onLolClientStarted(self, pid):
+        logger.info(f"League of Legends client started: {pid}", TAG)
         res = await self.__startConnector(pid)
         if not res:
             return
@@ -511,6 +512,7 @@ class MainWindow(FluentWindow):
 
     @asyncSlot(int)
     async def __onLolClientChanged(self, pid):
+        logger.critical(f"League of Legends client changed: {pid}", TAG)
         await self.__onLolClientEnded()
         self.processListener.runningPid = pid
         await self.__onLolClientStarted(pid)
@@ -903,13 +905,19 @@ class MainWindow(FluentWindow):
         title = self.tr('Exception occurred 😥')
         content = "".join(tracebackFormat)
 
+        if ty in [ConnectionRefusedError, ClientConnectorError]:
+            return
+
         logger.error("connector call_stack -------------- ↓", "Crash")
         for call in connector.call_stack:
             logger.error(call, "Crash")
         logger.error("connector call_stack -------------- ↑", "Crash")
 
-        if ty in [ConnectionRefusedError, ClientConnectorError]:
-            return
+        logger.error(str(self.searchInterface), "Crash")
+        logger.error(str(self.gameInfoInterface), "Crash")
+        logger.error(str(self.careerInterface), "Crash")
+        logger.error(str(self.auxiliaryFuncInterface), "Crash")
+        logger.error(str(self.settingInterface), "Crash")
 
         w = ExceptionMessageBox(title, content, self.window())
 

--- a/app/view/search_interface.py
+++ b/app/view/search_interface.py
@@ -291,6 +291,7 @@ class GameDetailView(QFrame):
 
         # self.vBoxLayout.addSpacerItem(
         #     QSpacerItem(1, 1, QSizePolicy.Minimum, QSizePolicy.Expanding))
+
     def setLoadingPageEnabled(self, enable: bool):
         if enable:
             index = 0
@@ -1090,7 +1091,11 @@ class SearchInterface(SmoothScrollArea):
 
         while True:
             # 为加载战绩详情让行
-            while self.detailViewLoadTask and not self.detailViewLoadTask.done():
+            while (
+                (self.detailViewLoadTask and not self.detailViewLoadTask.done())
+                or
+                (self.window().careerInterface.loadGamesTask and not self.window().careerInterface.loadGamesTask.done())
+            ):
                 await asyncio.sleep(.2)
 
             try:

--- a/app/view/search_interface.py
+++ b/app/view/search_interface.py
@@ -1030,8 +1030,12 @@ class SearchInterface(SmoothScrollArea):
             self.gameLoadingTask = None
 
         # 先加载两页，让用户看着
-        games = await connector.getSummonerGamesByPuuid(self.puuid, 0, 19)
-        games = await parseGamesDataConcurrently(games['games'])
+        try:
+            games = await connector.getSummonerGamesByPuuid(self.puuid, 0, 19)
+        except SummonerGamesNotFound:
+            games = []
+        else:
+            games = await parseGamesDataConcurrently(games['games'])
 
         if len(games) == 0:
             self.gamesView.gamesTab.nextButton.setVisible(False)
@@ -1089,7 +1093,12 @@ class SearchInterface(SmoothScrollArea):
         begIdx = 20
         endIdx = 29
 
-        while True:
+        # 若之前正在查, 先等task被release掉
+        while self.gameLoadingTask and not self.gameLoadingTask.done():
+            await asyncio.sleep(.2)
+
+        # 连续查多个人时, 将前面正在查的task给release掉
+        while self.puuid == puuid:
             # 为加载战绩详情让行
             while (
                 (self.detailViewLoadTask and not self.detailViewLoadTask.done())
@@ -1101,8 +1110,10 @@ class SearchInterface(SmoothScrollArea):
             try:
                 games = await connector.getSummonerGamesByPuuidSlowly(
                     puuid, begIdx, endIdx)
-            except:
-                # TODO 这里可以弹个窗
+            except SummonerGamesNotFound:
+                # TODO 这里可以弹个窗  -- By Zzaphkiel
+                # NOTE 触发 SummonerGamesNotFound 时, 异常信息会通过 connector 下发到 main_window 的 __onShowLcuConnectError
+                #  理论上会有弹框提示  -- By Hpero4
                 return
 
             # 1000 局搜完了，或者正好上一次就是最后
@@ -1173,6 +1184,8 @@ class SearchInterface(SmoothScrollArea):
 
         self.gamesView.setLoadingPageEnable(True)
 
+        # FIXME
+        #  需要全部加载完才会展示筛选
         await self.gameLoadingTask
 
         enable = tabs.queueIdMap.get(tabs.queueId) != None

--- a/app/view/search_interface.py
+++ b/app/view/search_interface.py
@@ -25,6 +25,7 @@ from app.components.animation_frame import ColorAnimationFrame, CardWidget
 from app.lol.connector import connector
 from app.lol.exceptions import SummonerGamesNotFound, SummonerNotFound
 from app.lol.tools import parseGameData, parseGameDetailData, parseGamesDataConcurrently
+from ..components.SeraphineInterface import SeraphineInterface
 
 
 class GamesTab(QFrame):
@@ -911,7 +912,7 @@ class GameTab(ColorAnimationFrame):
             1, 1, QSizePolicy.Expanding, QSizePolicy.Minimum))
 
 
-class SearchInterface(SmoothScrollArea):
+class SearchInterface(SeraphineInterface):
     summonerPuuidGetted = pyqtSignal(str)
     gamesNotFound = pyqtSignal()
 

--- a/app/view/setting_interface.py
+++ b/app/view/setting_interface.py
@@ -16,11 +16,12 @@ from ..common.icons import Icon
 from ..common.config import (
     cfg, YEAR, AUTHOR, VERSION, FEEDBACK_URL, GITHUB_URL, isWin11)
 from ..common.style_sheet import StyleSheet
+from ..components.SeraphineInterface import SeraphineInterface
 from ..components.setting_cards import (LineEditSettingCard, GameTabColorSettingCard,
                                         LooseSwitchSettingCard, ProxySettingCard)
 
 
-class SettingInterface(SmoothScrollArea):
+class SettingInterface(SeraphineInterface):
     """ Setting interface """
 
     def __init__(self, parent=None):

--- a/app/view/start_interface.py
+++ b/app/view/start_interface.py
@@ -9,6 +9,7 @@ from PyQt5.QtWidgets import (QHBoxLayout, QLabel, QWidget, QVBoxLayout,
 
 from app.common.qfluentwidgets import (InfoBar, InfoBarPosition, PushButton, SmoothScrollArea,
                                        IndeterminateProgressBar)
+from app.components.SeraphineInterface import SeraphineInterface
 
 from app.lol.connector import connector
 from app.common.config import cfg
@@ -19,7 +20,7 @@ from app.common.signals import signalBus
 from app.components.message_box import ChangeClientMessageBox
 
 
-class StartInterface(SmoothScrollArea):
+class StartInterface(SeraphineInterface):
     def __init__(self, parent: QWidget = None):
         super().__init__(parent)
 


### PR DESCRIPTION
1. 修复弱网条件下, rank信息获取异常导致的各种问题 (重要) #301
2. 修复了战绩查询时, 频繁切换查询的召唤师会导致此前的查询任务仍在进行的BUG (重要, 效率影响巨大)
3. 优化了生涯页的加载速度 