### PR TITLE
BUG FIX: 战绩查询相关问题

### DIFF
--- a/app/view/main_window.py
+++ b/app/view/main_window.py
@@ -884,11 +884,12 @@ class MainWindow(FluentWindow):
         name = self.careerInterface.getSummonerName()
         self.searchInterface.searchLineEdit.setText(name)
         self.checkAndSwitchTo(self.searchInterface)
+        self.searchInterface.filterComboBox.setCurrentIndex(0)  # 从生涯页跳过来默认将筛选条件设置为全部 -- By Hpero4
 
         await self.searchInterface.searchAndShowFirstPage()
         self.searchInterface.loadingGameId = gameId
+        self.searchInterface.waitingForDrawSelect(gameId)  # 先画框再加载对局 否则快速切换(如筛选或换人)会导致找不到widget -- By Hpero4
         await self.searchInterface.updateGameDetailView(gameId)
-        self.searchInterface.waitingForDrawSelect(gameId)
 
     @asyncSlot()
     async def __refreshCareerInterface(self):


### PR DESCRIPTION
1. 修复战绩查询时, 偶尔会出现重复战绩的BUG
2. 修复战绩查询时, 模式筛选需要等待全部战绩加载完成的BUG
3. 修复生涯页快速切换到战绩查询页并且换人时, 出现AttributeError的BUG