### PR TITLE
BUGFIX

### DIFF
--- a/app/view/main_window.py
+++ b/app/view/main_window.py
@@ -892,10 +892,9 @@ class MainWindow(FluentWindow):
     async def __onCareerGameClicked(self, gameId):
         name = self.careerInterface.getSummonerName()
         self.searchInterface.searchLineEdit.setText(name)
-        self.searchInterface.filterComboBox.setCurrentIndex(
-            0)  # 从生涯页跳过来默认将筛选条件设置为全部 -- By Hpero4
+        self.searchInterface.filterComboBox.setCurrentIndex(0)  # 从生涯页跳过来默认将筛选条件设置为全部 -- By Hpero4
 
-        await self.searchInterface.searchAndShowFirstPage()
+        await self.searchInterface.searchAndShowFirstPage(self.careerInterface.puuid)
         # 先加载完再切换, 避免加载过程中换搜索目标导致puuid出错 -- By Hpero4
         self.checkAndSwitchTo(self.searchInterface)
         self.searchInterface.loadingGameId = gameId


### PR DESCRIPTION
1. 修复从生涯页跳转到搜索页时, 战绩会乱的BUG
2. 修复从生涯页跳转到搜索页时, 可能会绘制多个选中框的BUG
3. 战绩查询功能支持puuid搜索
4. 修复了在搜索页切换搜索目标时, 极小概率会混入此前搜索目标的战绩的BUG