### PR TITLE
bugfix: 修复大乱斗buff卡片会受到主窗口大小限制显示不全; 移除了"游戏开始时最小化Seraphine"的设置选项以及功能

### DIFF
--- a/app/components/profile_level_icon_widget.py
+++ b/app/components/profile_level_icon_widget.py
@@ -1,9 +1,10 @@
 import sys
 
 from PyQt5.QtCore import Qt, QRectF, QPoint
-from PyQt5.QtGui import QPainter, QPainterPath, QPen, QFont, QPixmap
+from PyQt5.QtGui import QPainter, QPainterPath, QPen, QFont, QPixmap, QColor
 from PyQt5.QtWidgets import QWidget, QApplication, QMainWindow, QHBoxLayout, QLabel, QVBoxLayout, QGridLayout
 
+from app.common.util import AramHome
 from ..common.qfluentwidgets import ProgressRing, ToolTipFilter, ToolTipPosition, isDarkTheme, themeColor, \
     FlyoutViewBase, TextWrap
 
@@ -80,6 +81,8 @@ class RoundLevelAvatar(QWidget):
         self.mFlyout = None
         self.aramInfo = aramInfo
 
+        # self.aramInfo = AramHome.getInfoByHeroId("75")  # Note 如果你希望测试大乱斗的数据弹框, 参考这个 -- By Hpero4
+
     def paintEvent(self, event):
         if self.paintXpSinceLastLevel != self.xpSinceLastLevel or self.paintXpUntilNextLevel != self.xpUntilNextLevel or self.callUpdate:
             self.progressRing.setVal(self.xpSinceLastLevel * 100 //
@@ -141,7 +144,7 @@ class RoundLevelAvatar(QWidget):
                 self.mFlyout = AramFlyout(
                     info=self.aramInfo,
                     target=self,
-                    parent=self.window()
+                    parent=None
                 )
                 self.mFlyout.show()
                 # TODO Animation -- By Hpero4
@@ -160,6 +163,13 @@ class RoundLevelAvatar(QWidget):
 class AramFlyout(FlyoutViewBase):
     def __init__(self, info, target, parent=None):
         super().__init__(parent=parent)
+
+        self.setWindowFlags(Qt.FramelessWindowHint | Qt.Tool)
+        self.setAttribute(Qt.WA_TranslucentBackground)
+
+        self.setWindowFlags(Qt.FramelessWindowHint)
+        self.setStyleSheet("background-color: rgba(255, 255, 255, 0);")
+
         self.info = info
         self.target = target
 
@@ -199,9 +209,8 @@ class AramFlyout(FlyoutViewBase):
 
     def calcPoints(self):
         pos = self.target.mapToGlobal(QPoint())
-        windowPos = self.window().mapToGlobal(QPoint())
-        x = pos.x() + self.target.width() // 2 - self.sizeHint().width() // 2 - windowPos.x()
-        y = pos.y() - self.sizeHint().height() - 12 - windowPos.y()
+        x = pos.x() + self.target.width() // 2 - self.sizeHint().width() // 2
+        y = pos.y() - self.sizeHint().height() - 12
 
         if x < 5:
             x = 5

--- a/app/view/main_window.py
+++ b/app/view/main_window.py
@@ -78,8 +78,9 @@ class MainWindow(FluentWindow):
             target=self.checkUpdate, parent=self)
         self.checkNoticeThread = StoppableThread(
             target=lambda: self.checkNotice(False), parent=self)
-        self.minimizeThread = StoppableThread(
-            target=self.gameStartMinimize, parent=self)
+        # 该功能不再支持 -- By Hpero4
+        # self.minimizeThread = StoppableThread(
+        #     target=self.gameStartMinimize, parent=self)
 
         logger.critical("Seraphine listerners started", TAG)
 
@@ -431,7 +432,7 @@ class MainWindow(FluentWindow):
         self.processListener.start()
         self.checkUpdateThread.start()
         self.checkNoticeThread.start()
-        self.minimizeThread.start()
+        # self.minimizeThread.start()  # 该功能不再支持 -- By Hpero4
 
     async def __changeCareerToCurrentSummoner(self):
         summoner = await connector.getCurrentSummoner()
@@ -671,13 +672,12 @@ class MainWindow(FluentWindow):
     def __lockInterface(self):
         self.searchInterface.setEnabled(False)
         self.auxiliaryFuncInterface.setEnabled(False)
-        # pass
 
     def __terminateListeners(self):
         self.processListener.terminate()
         self.checkUpdateThread.terminate()
         self.checkNoticeThread.terminate()
-        self.minimizeThread.terminate()
+        # self.minimizeThread.terminate()  # 该功能不再支持 -- By Hpero4
 
     @asyncClose
     async def closeEvent(self, a0) -> None:

--- a/app/view/setting_interface.py
+++ b/app/view/setting_interface.py
@@ -238,7 +238,7 @@ class SettingInterface(SeraphineInterface):
         self.generalGroup.addSettingCard(self.enableStartLolWithApp)
         self.generalGroup.addSettingCard(self.deleteResourceCard)
         self.generalGroup.addSettingCard(self.enableCloseToTray)
-        self.generalGroup.addSettingCard(self.gameStartMinimizeCard)
+        # self.generalGroup.addSettingCard(self.gameStartMinimizeCard)  # 该功能不再支持, 隐藏它 -- By Hpero4
         self.generalGroup.addSettingCard(self.logLevelCard)
         self.generalGroup.addSettingCard(self.viewLogCard)
 


### PR DESCRIPTION
1. 修复大乱斗buff卡片会受到主窗口大小限制显示不全; 
2. 移除了"游戏开始时最小化Seraphine"的设置选项以及功能