### PR TITLE
FIX: 特定条件下, 战绩查询会干掉客户端

### DIFF
--- a/app/components/search_line_edit.py
+++ b/app/components/search_line_edit.py
@@ -154,3 +154,8 @@ class SearchLineEdit(QSearchLineEdit):
         if e.reason() != 4:
             self._showCompleterMenu()
             super().focusInEvent(e)
+
+    def mousePressEvent(self, e):
+        if self.hasFocus():
+            self._showCompleterMenu()
+        super().mousePressEvent(e)

--- a/app/lol/connector.py
+++ b/app/lol/connector.py
@@ -3,6 +3,7 @@ import os
 import json
 import threading
 import re
+from asyncio import CancelledError
 from collections import deque
 
 import requests
@@ -86,6 +87,12 @@ def retry(count=5, retry_sep=0):
                 try:
                     async with connector.semaphore:
                         res = await func(*args, **kwargs)
+                except CancelledError:
+                    # Fix: 使用task.cancel()偶尔会停不下task -- By Hpero4
+                    #   在调用cancel()时, 会从调用栈的最底抛出CancelledError, 最终传递到loop终止task;
+                    #   由于CancelledError是BaseException的子类,
+                    #   若task恰好跑到被retry装饰的函数中, 会被retry中的BaseException捕获并吞掉, 从而无事发生
+                    raise
                 except BaseException as e:
                     time.sleep(retry_sep)
                     exce = e

--- a/app/lol/connector.py
+++ b/app/lol/connector.py
@@ -331,7 +331,7 @@ class LolClientConnector(QObject):
             "profile icons",
             "rune icons",
             "summoner spell icons",
-            "augment icons"
+            "augment icons",
             "splashes",
         ]:
             p = f"app/resource/game/{folder}"

--- a/app/view/search_interface.py
+++ b/app/view/search_interface.py
@@ -1098,6 +1098,7 @@ class SearchInterface(SeraphineInterface):
             parent=self
         )
 
+    # Fix: 超快速的在候选栏选中两次同样puuid会起两个task加载战绩, 100%干掉客户端 -- By Hpero4
     @asyncLockDecorator('loadFirstPageLock')
     async def searchAndShowFirstPage(self, puuid=None):
         name = self.searchLineEdit.text()
@@ -1108,8 +1109,6 @@ class SearchInterface(SeraphineInterface):
             summoner = await connector.getSummonerByPuuid(name)
         else:
             summoner = await connector.getSummonerByName(name)
-            # Fix: 超快速的在候选栏选中两次同样puuid会起两个task加载战绩, 100%干掉客户端 -- By Hpero4
-            puuid = summoner['puuid']
 
         if 'errorCode' in summoner:
             self.__showSummonerNotFoundMsg()

--- a/app/view/search_interface.py
+++ b/app/view/search_interface.py
@@ -11,6 +11,8 @@ from PyQt5.QtWidgets import (QVBoxLayout, QHBoxLayout, QFrame,
                              QSpacerItem, QSizePolicy, QLabel, QStackedWidget, QWidget)
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QPixmap, QColor
+
+from ..common.logger import logger
 from ..common.qfluentwidgets import (SmoothScrollArea, PushButton, ToolButton, InfoBar,
                                      InfoBarPosition, ToolTipFilter, ToolTipPosition,
                                      isDarkTheme, FlyoutViewBase, Flyout, Theme,
@@ -29,6 +31,23 @@ from app.lol.connector import connector
 from app.lol.exceptions import SummonerGamesNotFound, SummonerNotFound
 from app.lol.tools import parseGameData, parseGameDetailData, parseGamesDataConcurrently
 from ..components.seraphine_interface import SeraphineInterface
+
+
+TAG = "SearchInterface"
+
+
+def asyncLockDecorator(lockName):
+    """
+    给任何一个方法加锁, return时释放
+    args[0]是self, 通过getattr找到lockName
+    """
+    def decorator(func):
+        async def wrapper(*args, **kwargs):
+            lock = getattr(args[0], lockName)
+            async with lock:
+                return await func(*args, **kwargs)
+        return wrapper
+    return decorator
 
 
 class GamesTab(QFrame):
@@ -1008,6 +1027,8 @@ class SearchInterface(SeraphineInterface):
         self.detailViewLoadTask = None
         self.loadingGameId = 0
 
+        self.loadFirstPageLock = asyncio.Lock()
+
         self.__initWidget()
         self.__initLayout()
         self.__connectSignalToSlot()
@@ -1077,6 +1098,7 @@ class SearchInterface(SeraphineInterface):
             parent=self
         )
 
+    @asyncLockDecorator('loadFirstPageLock')
     async def searchAndShowFirstPage(self, puuid=None):
         name = self.searchLineEdit.text()
         if name == "":
@@ -1086,6 +1108,8 @@ class SearchInterface(SeraphineInterface):
             summoner = await connector.getSummonerByPuuid(name)
         else:
             summoner = await connector.getSummonerByName(name)
+            # Fix: 超快速的在候选栏选中两次同样puuid会起两个task加载战绩, 100%干掉客户端 -- By Hpero4
+            puuid = summoner['puuid']
 
         if 'errorCode' in summoner:
             self.__showSummonerNotFoundMsg()
@@ -1105,9 +1129,7 @@ class SearchInterface(SeraphineInterface):
 
                 while not self.gameLoadingTask.cancelled() \
                         and not self.gameLoadingTask.done():
-                    # FIX: task有可能会错过cancel(), 导致必须等到查询结束; -- By Hpero4
-                    self.gameLoadingTask.cancel()
-                    await asyncio.sleep(.2)
+                    await asyncio.sleep(.3)
 
             self.puuid = summoner['puuid']
             self.gamesView.gamesTab.clear()
@@ -1132,7 +1154,6 @@ class SearchInterface(SeraphineInterface):
             # 启动任务，往 gamesTab 里丢数据
             # NOTE 既然创建新任务, 并且刷新了self.puuid 就应该用self的, 否则就违背了loadGames判断的初衷
 
-            # FIXME: 当从两名召唤师之间反复横跳时, 有可能会导致一puuid起了2个(或更多)task -- By Hpero4
             self.gameLoadingTask = asyncio.create_task(
                 self.__loadGames(self.puuid))
 
@@ -1188,12 +1209,15 @@ class SearchInterface(SeraphineInterface):
         begIdx = 20
         endIdx = 29
 
+        logger.debug(f"welcome load games task: {puuid}", TAG)
+
         # NOTE 换了查询目标, 若之前正在查, 先等 task 被 release 掉 -- By Hpero4
         while self.gameLoadingTask \
                 and not self.gameLoadingTask.done() \
                 and puuid != self.puuid:
             await asyncio.sleep(.2)
 
+        logger.debug(f"start load {puuid}", TAG)
         # 连续查多个人时, 将前面正在查的task给release掉
         while self.puuid == puuid:
             # 为加载战绩详情让行
@@ -1205,6 +1229,7 @@ class SearchInterface(SeraphineInterface):
             ):
                 await asyncio.sleep(.2)
 
+            t1 = time.time()
             try:
                 games = await connector.getSummonerGamesByPuuidSlowly(
                     puuid, begIdx, endIdx)
@@ -1213,7 +1238,9 @@ class SearchInterface(SeraphineInterface):
                 # NOTE 触发 SummonerGamesNotFound 时, 异常信息会通过 connector 下发到 main_window 的 __onShowLcuConnectError
                 #  理论上会有弹框提示  -- By Hpero4
                 return
+            t2 = time.time()
 
+            logger.debug(f"load games {self.puuid} [{begIdx}-{endIdx}] finish {t2-t1}s", TAG)
             # 1000 局搜完了，或者正好上一次就是最后
             # 在切换了puuid时, 就不要再把数据刷到Games上了 -- By Hpero4
             if games['gameCount'] == 0 or self.puuid != puuid:


### PR DESCRIPTION
1. FIX 连续在候选栏选中两次相同召唤师会起两个task同时加载导致客户端闪退
2. FIX 使用cancel()有时候无法终止task
3. 优化战绩搜索UI响应速度