### PR TITLE
fix bug in opgg_window

### DIFF
--- a/app/view/opgg_window.py
+++ b/app/view/opgg_window.py
@@ -501,7 +501,7 @@ class OpggWindow(OpggWindowBase):
         dpi = self.devicePixelRatioF()
         x = pos.right()
         y = pos.center().y() - size.height() * dpi / 2
-        rect = QRect(x / dpi, y / dpi, size.width(), size.height())
+        rect = QRect(x // dpi, y // dpi, size.width(), size.height())
 
         # 如果超出右边界，则直接 return 了
         screenWidth = win32api.GetSystemMetrics(0)


### PR DESCRIPTION
https://github.com/Zzaphkiel/Seraphine/blob/e6f1b423bcdbefbf83f28b402667f9cb55ca0073/app/view/opgg_window.py#L504

QRect requires int type, not float.
